### PR TITLE
[fix] #31 모바일 일부 기기에서 alignItems가 적용되지 않는 경우 수정

### DIFF
--- a/src/component/Header/Header.style.jsx
+++ b/src/component/Header/Header.style.jsx
@@ -8,7 +8,7 @@ export const headContainer = css(
 
     display: 'flex',
     justifyContent: 'center',
-    alignItems: 'end',
+    alignItems: 'flex-end',
   })
 );
 


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 모바일 일부 기기 `iPhone X` 등에서 아래와 같이 나오는 경우가 발생합니다.
![image](https://user-images.githubusercontent.com/86355699/220869236-cff8d8db-f25e-4194-92b7-b02635525b12.png)

- 이를 수정하기 위하여 안정성성이 낮은 `end` 대신 `flex-end`를 사용하였습니다.

## 2. 어떤 위험이나 장애를 발견했나요?
- `end`를 사용하더라도, 일부 기기에서는 올바르게 동작하고 다른 기계에선 동작하지 않고 있습니다.
- 이 차이가 발생하는 원인에 대해 더 확실한 확인이 필요합니다.
- 만약 올바르게 적용되지 않은 경우 `lineHeight` 값을 사용하여야 합니다.
